### PR TITLE
Dynamic auto completes

### DIFF
--- a/entryForm.html
+++ b/entryForm.html
@@ -23,14 +23,15 @@
 			<option selected value="1">Episode</option>
 			<option value="2">Multi-Part: Unfinished</option>
 			<option value="3">Multi-Part: Completed</option>
-			<option value="4">Ads</option>
+			<option value="4">Sponsor</option>
 			<option value="5">Patreon Bonus</option>
 		</select>
 
 		<!-- ░░░░░▓ VIDEO LABEL -->
 		<div class="form-group pt-2" id="label_group">
 			<label for="label" class="form-label">Label Footage</label>
-			<input type="text" class="form-control" id="label">
+			<input type="text" class="form-control" id="label" list="sponsorAutoPopulate">
+				<datalist id="sponsorAutoPopulate"></datalist>
 		</div>
 
 		<!-- ░░░░░▓ MULTI: LINKED VIDEO DROPDOWN -->
@@ -464,6 +465,21 @@
 	}
 
 
+// ░░░░░░░░░▓ POPULATE FOOTAGE LABEL AUTO-COMPLETE WITH UNIQUE PREVIOUS SPONSORS
+	function populateSponsorLabel(){
+		let currentlyAdded = [];
+
+		arrayOfValues.sponsors.forEach(function(el){
+				if (currentlyAdded.indexOf(el[0]) === -1) {
+					let option = document.createElement("option");
+					option.textContent = el[0];
+					sponsorAutoPopulate.appendChild(option);
+					currentlyAdded.push(el[0]);
+				}
+		});
+	}
+
+
 // ░░░░░░░░░▓ POPULATE LOCATION FIELD 1 AUTO-COMPLETE WITH UNIQUE PREVIOUS LOCATIONS
 	function populateLocationField1(index){
 		let currentlyAdded = [];
@@ -501,6 +517,7 @@
 		};
 	}
 
+
 // ░░░░░░░░░▓ RETURNS JUST THE INDEX NUMBERS OF EVERY MATCHING ELEMENT IN AN ARRAY
 	function getAllIndexes(arr, el) {
 		var indexes = [], i;
@@ -524,20 +541,28 @@
 	function updateTypeDependentFields(){
 		var contCheck = document.getElementById("cont_check_group");
         
-			if(type.value === "3"){
-				labelGroup.classList.add("d-none");
-				contGroup.classList.remove("d-none");
-				contCheck.classList.add("d-none");
+			if(type.value === "3"){						// "Multi-Part: Completed"
+				labelGroup.classList.add("d-none");		// hide text field
+				contGroup.classList.remove("d-none");	// show drop down
+				contCheck.classList.add("d-none");		// hide continuation check
 				
-			} else if(type.value === "2") {
-				labelGroup.classList.remove("d-none");
-				contGroup.classList.add("d-none");
-				contCheck.classList.remove("d-none");
+			} else if(type.value === "2") {				// "Multi-Part: Unfinished"
+				labelGroup.classList.remove("d-none");	// show text field
+				contGroup.classList.add("d-none");		// hide drop down
+				contCheck.classList.remove("d-none");	// show continuation check
+				emptyDatalist(["sponsorAutoPopulate"]);	// removes sponsor datalist if already loaded
+				
+			} else if(type.value === "4") {				// "Sponsor"
+				labelGroup.classList.remove("d-none");	// show text field
+				contGroup.classList.add("d-none");		// hide drop down
+				contCheck.classList.add("d-none");		// hide continuation check
+				populateSponsorLabel();					// give options for auto-complete
 				
 			} else {
-				labelGroup.classList.remove("d-none");
-				contGroup.classList.add("d-none");
-				contCheck.classList.add("d-none");
+				labelGroup.classList.remove("d-none");	// show text field
+				contGroup.classList.add("d-none");		// hide drop down
+				contCheck.classList.add("d-none");		// hide continuation check
+				emptyDatalist(["sponsorAutoPopulate"]);	// removes sponsor datalist if already loaded
 			}
 	}
 
@@ -745,8 +770,9 @@
 
 
 // ░░░░░░░░░▓ FUNCTION FOR CLEARING DATA
-	function clearFields(fields){
-		fields.forEach(function(field){
+	function clearFields(fieldCollection) {
+		
+		fieldCollection.forEach(function(field){
 			var el = document.getElementById(field);
 			if(el.type === "checkbox" || el.type === "radio"){
 				el.checked = false;
@@ -756,6 +782,17 @@
 		});
 	}
 
+// ░░░░░░░░░▓ FUNCTION FOR CLEARING A DATALIST
+	function emptyDatalist(fieldCollection) {
+		
+		fieldCollection.forEach(function(field) {
+			let dataL = document.getElementById(field);
+		
+			while (dataL.hasChildNodes()) {
+				dataL.removeChild(dataL.firstChild);
+			}
+		});
+	}
 
 // ░░░░░░░░░▓ LISTENERS THAT RUN FUNCTIONS WHEN SOMETHING HAPPENS
 	document.getElementById("submitButton").addEventListener("click",afterButtonClicked);

--- a/entryForm.html
+++ b/entryForm.html
@@ -142,8 +142,10 @@
 		</div>
 
 		<div class="input-group">
-			<input type="text" id="location_property" value="HQ" class="form-control col-4" data-bs-toggle="tooltip" data-bs-placement="top" title="property (wide category)" onclick="this.select();">
-			<input type="text" id="location_room" value="soundstage" class="form-control col-6" data-bs-toggle="tooltip" data-bs-placement="top" title="area on property (narrow category)" onclick="this.select();">
+			<input type="text" id="location_property" value="HQ" class="form-control col-4" data-bs-toggle="tooltip" data-bs-placement="top" title="property (wide category)" onfocus="this.value=''" list="locationWideAutoPopulate">
+				<datalist id="locationWideAutoPopulate"></datalist>
+			<input type="text" id="location_room" value="soundstage" class="form-control col-6" data-bs-toggle="tooltip" data-bs-placement="top" title="area on property (narrow category)" onfocus="this.value=''" list="locationNarrowAutoPopulate">
+				<datalist id="locationNarrowAutoPopulate"></datalist>
 		</div>
 
 		<!-- ░░░░░▓ CREW ROLE BUTTONS -->
@@ -447,26 +449,74 @@
 	}
 
 
-// ░░░░░░░░░▓ POPULATE LABEL DROPDOWN WITH PREVIOUS LABELS
-	function addUniqueOptionsToDropdownList(contDropDown,arrayOfValues,index){
-		var currentlyAdded = [];
+// ░░░░░░░░░▓ POPULATE FOOTAGE LABEL DROPDOWN WITH UNIQUE PREVIOUS LABELS FROM INCOMPLETE EPS
+	function populateContEpDropDown(contDropDown, index){
+		let currentlyAdded = [];
 
-		arrayOfValues.unfinished.forEach(function(r){
-			if(currentlyAdded.indexOf(r[index]) === -1){
-				var option = document.createElement("option");
-				option.textContent = r[index];
+		arrayOfValues.unfinished.forEach(function(el){
+			if(currentlyAdded.indexOf(el[index]) === -1){
+				let option = document.createElement("option");
+				option.textContent = el[index];
 				contDropDown.appendChild(option);
-				currentlyAdded.push(r[index]);
+				currentlyAdded.push(el[index]);
 			}
 		});
 	}
 
 
-// ░░░░░░░░░▓ I DON'T REMEMBER, SOMETHING TO DO WITH
-// ░░░░░░░░░▓ ONLY ALLOWING UNIQUE ENTRIES INTO CONTINUATION DROPDOWN
+// ░░░░░░░░░▓ POPULATE LOCATION FIELD 1 AUTO-COMPLETE WITH UNIQUE PREVIOUS LOCATIONS
+	function populateLocationField1(index){
+		let currentlyAdded = [];
+
+		arrayOfValues.locationsWide.forEach(function(el){
+			if(currentlyAdded.indexOf(el[index]) === -1){
+				let option = document.createElement("option");
+				option.textContent = el[index];
+				locationWideAutoPopulate.appendChild(option);
+				currentlyAdded.push(el[index]);
+			}
+		});
+	}
+
+
+// ░░░░░░░░░▓ POPULATE LOCATION FIELD 2 AUTO-COMPLETE WITH LOCATIONS ASSOCIATED WITH FIELD 1 SELECTION
+	function populateLocationField2(locationField1, index){
+		const locWide = arrayOfValues.locationsWide;
+		const locNar = arrayOfValues.locationsNarrow;
+		let matchingWideIndex = getAllIndexes(locWide, locationField1);
+		let currentlyAdded = [];
+		
+		document.getElementById("locationNarrowAutoPopulate").innerHTML = '';
+		
+		for(i = 0; i < matchingWideIndex.length; i++){
+			var curMatch = matchingWideIndex[i];
+			var curLocNar = locNar[curMatch];
+			
+			if(currentlyAdded.indexOf(curLocNar[0]) === -1){
+				let option = document.createElement("option");
+				option.textContent = curLocNar[0];
+				locationNarrowAutoPopulate.appendChild(option);
+				currentlyAdded.push(curLocNar[0]);
+			};
+		};
+	}
+
+// ░░░░░░░░░▓ RETURNS JUST THE INDEX NUMBERS OF EVERY MATCHING ELEMENT IN AN ARRAY
+	function getAllIndexes(arr, el) {
+		var indexes = [], i;
+		for(i = 0; i < arr.length; i++)
+			if (arr[i] == el)
+				indexes.push(i);
+		return indexes;
+	}
+
+
+// ░░░░░░░░░▓ SENDS DATAARRAY OBJECT / VALUES TO POPULATECONTEPDORPDOWN FUNCTION
 	function afterSpreadsheetDataReturned(dataArray){
 		arrayOfValues = JSON.parse(JSON.stringify(dataArray));
-		addUniqueOptionsToDropdownList(contDropDown,arrayOfValues,0);
+		populateContEpDropDown(contDropDown,0);
+		populateLocationField1(0);
+		populateLocationField2(document.getElementById("location_property").value, 0);
 	}
 
 
@@ -721,6 +771,7 @@
 	document.getElementById("inlineEliOtherCheckbox").addEventListener("click", function(){ afterCrewRoleOtherClicked("inlineEliOther") });
 	document.getElementById("inlineJeffOtherCheckbox").addEventListener("click", function(){ afterCrewRoleOtherClicked("inlineJeffOther") });
 	document.getElementById("type_of_video").addEventListener("change",updateTypeDependentFields);
+	document.getElementById("location_property").addEventListener("change", function(){ populateLocationField2(document.getElementById("location_property").value,0) });
 	document.addEventListener("DOMContentLoaded",afterSidebarLoads);
 	</script>
 

--- a/entryForm.html
+++ b/entryForm.html
@@ -392,7 +392,7 @@
 
 		<!-- ░░░░░▓ VERSION NUMBER TEXT -->
 		<div class="d-flex justify-content-center" id="version_number">
-			<div class="form-text pt-3 ">alpha version 0.85</div>
+			<div class="form-text pt-3 ">alpha version 0.95</div>
 		</div>
 	</div>
 

--- a/functs.gs
+++ b/functs.gs
@@ -3,10 +3,12 @@ const ss = SpreadsheetApp.getActiveSpreadsheet();
 const tab1 = ss.getSheetByName("Production Order");
 const tab2 = ss.getSheetByName("Release Order");
 const rangeOffset = 810;
+const locOffset = 750;
 var prodOffset = -1;
 var dataArray = {
 				unfinished: [],
-				locations: [],
+				locationsWide: [],
+				locationsNarrow: [],
 				allLabels: [],
 				};
 
@@ -61,15 +63,18 @@ function addNewRow(rowData) {
 function getSpreadsheetData(){
 	const lastRow = tab1.getLastRow();
 	const labelRange = tab1.getRange(rangeOffset,12,lastRow - (rangeOffset-1),1);
-	const locationRange = tab1.getRange(810,19,lastRow - (810-1),2);
+	const locationWideRange = tab1.getRange(locOffset,19,lastRow - (locOffset-1),1);
+	const locationNarrowRange = tab1.getRange(locOffset,20,lastRow - (locOffset-1),1);
 
-	for ( i = 0; i < ((lastRow + 1) - rangeOffset); i++){
-		if (labelRange.getBackgrounds()[i] == "#ffff00")
-			{ dataArray.unfinished.push(labelRange.getValues()[i]) };
+		for ( i = 0; i < ((lastRow + 1) - locOffset); i++){
+			if (labelRange.getBackgrounds()[i] == "#ffff00")
+				{ dataArray.unfinished.push(labelRange.getValues()[i]) };
 
-		if (locationRange.getValues()[i] != "")
-			{ dataArray.locations.push(locationRange.getValues()[i]); };
-	}
+			if (locationWideRange.getValues()[i] != "")
+				{	dataArray.locationsWide.push(locationWideRange.getValues()[i]);
+					dataArray.locationsNarrow.push(locationNarrowRange.getValues()[i]);
+				};
+		};
 
 	return dataArray;
 }
@@ -195,12 +200,12 @@ function closeIncompletes(type, cont, label) {
 
 		firstMatch = labelMatchedRow.shift();
 		tab1.getRange(firstMatch + ":" + firstMatch).setBackground("#f1c232");
-		labelMatchedRow.forEach(recolorIncompleteRotab1);
+		labelMatchedRow.forEach(recolorIncompleteRowTab1);
 	}
 }
 
 // ░░░░░░░░░▓ CLOSEINCOMPLETES -- THIS ACTUALLY SETS THE BACKGROUND COLOR
-function recolorIncompleteRotab1(item){
+function recolorIncompleteRowTab1(item){
 	tab1.getRange(item + ":" + item).setBackground("#e69138");
 }
 

--- a/functs.gs
+++ b/functs.gs
@@ -3,7 +3,7 @@ const ss = SpreadsheetApp.getActiveSpreadsheet();
 const tab1 = ss.getSheetByName("Production Order");
 const tab2 = ss.getSheetByName("Release Order");
 const rangeOffset = 810;
-const locOffset = 750;
+const locOffset = 500;
 var prodOffset = -1;
 var dataArray = {
 				unfinished: [],

--- a/functs.gs
+++ b/functs.gs
@@ -2,7 +2,7 @@
 const ss = SpreadsheetApp.getActiveSpreadsheet();
 const tab1 = ss.getSheetByName("Production Order");
 const tab2 = ss.getSheetByName("Release Order");
-const rangeOffset = 810;
+const rangeOffset = 700;
 const locOffset = 500;
 var prodOffset = -1;
 var dataArray = {
@@ -10,6 +10,8 @@ var dataArray = {
 				locationsWide: [],
 				locationsNarrow: [],
 				allLabels: [],
+				allLabelsString: [],
+				sponsors: []
 				};
 
 
@@ -67,14 +69,21 @@ function getSpreadsheetData(){
 	const locationNarrowRange = tab1.getRange(locOffset,20,lastRow - (locOffset-1),1);
 
 		for ( i = 0; i < ((lastRow + 1) - locOffset); i++){
-			if (labelRange.getBackgrounds()[i] == "#ffff00")
-				{ dataArray.unfinished.push(labelRange.getValues()[i]) };
+			if (labelRange.getBackgrounds()[i] == "#ffff00") {
+				dataArray.unfinished.push(labelRange.getValues()[i])
+			};
 
-			if (locationWideRange.getValues()[i] != "")
-				{	dataArray.locationsWide.push(locationWideRange.getValues()[i]);
-					dataArray.locationsNarrow.push(locationNarrowRange.getValues()[i]);
-				};
+			if (locationWideRange.getValues()[i] != "") {
+				dataArray.locationsWide.push(locationWideRange.getValues()[i]);
+				dataArray.locationsNarrow.push(locationNarrowRange.getValues()[i]);
+			};
+				
+			if (labelRange.getValues()[i] != "") {
+				dataArray.allLabels.push(labelRange.getValues()[i])
+			};
 		};
+		
+	dataArray.sponsors = labelRange.getValues().filter(value => /^ad: /i.test(value));
 
 	return dataArray;
 }
@@ -93,7 +102,7 @@ function determineProdNum(type, cont, label){
 		{ prodArray.push(Number(prodNumRange.getValues()[i])); };
 
 		if (labelRange.getValues()[i] != "")
-		{ dataArray.allLabels.push(String(labelRange.getValues()[i])) };
+		{ dataArray.allLabelsString.push(String(labelRange.getValues()[i])) };
 
 		prodNumIndex.push(Number(prodNumRange.getValues()[i]));
 	};
@@ -108,10 +117,10 @@ function determineProdNum(type, cont, label){
 			prodOffset++;
 			return mostRecentNum + prodOffset;
 		} else if (cont === "CONT") {
-			return prodNumIndex[dataArray.allLabels.indexOf(label)];
+			return prodNumIndex[dataArray.allLabelsString.indexOf(label)];
 		}
 	} else if (type == 3){
-		return prodNumIndex[dataArray.allLabels.indexOf(label)];
+		return prodNumIndex[dataArray.allLabelsString.indexOf(label)];
 	} else {
 		return "-";
 	}


### PR DESCRIPTION
### NEW FEATURE
Three text fields now auto-complete with suggestions from previous footage entries. These are data entries that are typically recurring, so auto-complete is a natural aid with the flexibility to change.

`Sponsor Label`
When a "sponsor" type of footage is selected, the label field automatically populates a datalist with previous unique footage entries that start with the text "ad:" which is then cleared if another type of footage is selected.

`Location Field 1`
This field represents a property on which the footage was recorded, and auto-populates with all recent unique entries into this field.

`Location Field 2`
This field represents the room or more specific area where the footage was recorded. It auto-populates similarly to field 1, although it is also conditional to field 1, since it represents a sub-category. Therefor, field 2 changes so that it only displays relevant locations associated with the general area provided in field 1.